### PR TITLE
Port SubstitutionMapProvider, RenamingType, and OutputRenamingMapFormat

### DIFF
--- a/src/com/google/common/css/BUILD.bazel
+++ b/src/com/google/common/css/BUILD.bazel
@@ -94,9 +94,11 @@ ts_library(
         "multiple-mapping-substitution-map.ts",
         "prefixing-substitution-map.ts",
         "recording-substitution-map.ts",
+        "renaming-type.ts",
         "simple-substitution-map.ts",
         "splitting-substitution-map.ts",
         "substitution-map.ts",
+        "substitution-map-provider.ts",
     ],
     deps = [
       "@npm//@types",
@@ -121,9 +123,11 @@ npm_package_bin(
         "babel-out/multiple-mapping-substitution-map.js",
         "babel-out/prefixing-substitution-map.js",
         "babel-out/recording-substitution-map.js",
+        "babel-out/renaming-type.js",
         "babel-out/simple-substitution-map.js",
         "babel-out/splitting-substitution-map.js",
-        "babel-out/substitution-map.js"
+        "babel-out/substitution-map.js",
+        "babel-out/substitution-map-provider.js",
     ],
     data = [
         ":css_ts_js",

--- a/src/com/google/common/css/compiler/commandline/renaming-type.ts
+++ b/src/com/google/common/css/compiler/commandline/renaming-type.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package com.google.common.css.compiler.commandline;
-
-import com.google.common.css.IdentitySubstitutionMap;
-import com.google.common.css.MinimalSubstitutionMap;
-import com.google.common.css.SimpleSubstitutionMap;
-import com.google.common.css.SplittingSubstitutionMap;
-import com.google.common.css.SubstitutionMap;
-import com.google.common.css.SubstitutionMapProvider;
+import { IdentitySubstitutionMap } from '../../identity-substitution-map';
+import { MinimalSubstitutionMap } from '../../minimal-substitution-map';
+import { OutputRenamingMapFormat } from '../../output-renaming-map-format';
+import { PrefixingSubstitutionMap } from '../../prefixing-substitution-map';
+import { RecordingSubstitutionMap } from '../../recording-substitution-map';
+import { SimpleSubstitutionMap } from '../../simple-substitution-map';
+import { SplittingSubstitutionMap } from '../../splitting-substitution-map';
+import { SubstitutionMap } from '../../substitution-map';
+import { SubstitutionMapProvider } from '../../substitution-map-provider';
 
 /**
  * {@link RenamingType} is an enumeration of the possible values for the
@@ -31,45 +32,63 @@ import com.google.common.css.SubstitutionMapProvider;
  *
  * @author bolinfest@google.com (Michael Bolin)
  */
-enum RenamingType {
-  /** No renaming is done. */
-  NONE(new SubstitutionMapProvider() {
-    @Override
-    public SubstitutionMap get() {
-      return new IdentitySubstitutionMap();
+class RenamingType {
+  private readonly provider: SubstitutionMapProvider;
+
+  constructor(provider: SubstitutionMapProvider) {
+    this.provider = provider;
+  }
+
+  getCssSubstitutionMapProvider(): SubstitutionMapProvider {
+    return this.provider;
+  }
+}
+
+namespace RenamingType {
+  const NULL_RENAMING_TYPE = new RenamingType(new class implements SubstitutionMapProvider {
+    public get(): SubstitutionMap {
+      throw Error('Undefined renaming type');
     }
-  }),
+  });
+
+  /** No renaming is done. */
+  export const NONE = NULL_RENAMING_TYPE;
+  Object.defineProperty(RenamingType, 'NONE', {
+    enumerable: true,
+    get: () => new RenamingType(new class implements SubstitutionMapProvider {
+      public get(): SubstitutionMap {
+        return new IdentitySubstitutionMap();
+      }
+    })
+  });
 
   /** A trailing underscore is added to each part of a CSS class. */
-  DEBUG(new SubstitutionMapProvider() {
-    @Override
-    public SubstitutionMap get() {
-      // This wraps the SimpleSubstitutionMap in a SplittingSubstitutionMap so
-      // that can be used with goog.getCssName().
-      return new SplittingSubstitutionMap(new SimpleSubstitutionMap());
-    }
-  }),
+  export const DEBUG = NULL_RENAMING_TYPE;
+  Object.defineProperty(RenamingType, 'DEBUG', {
+    enumerable: true,
+    get: () => new RenamingType(new class implements SubstitutionMapProvider {
+      public get(): SubstitutionMap {
+        // This wraps the SimpleSubstitutionMap in a SplittingSubstitutionMap so
+        // that can be used with goog.getCssName().
+        return new SplittingSubstitutionMap(new SimpleSubstitutionMap());
+      }
+    })
+  });
 
 
   /**
    * Each chunk of a CSS class as delimited by '-' is renamed using the
    * shortest available name.
    */
-  CLOSURE(new SubstitutionMapProvider() {
-    @Override
-    public SubstitutionMap get() {
-      return new SplittingSubstitutionMap(new MinimalSubstitutionMap());
-    }
-  }),
-  ;
-
-  private final SubstitutionMapProvider provider;
-
-  private RenamingType(SubstitutionMapProvider provider) {
-    this.provider = provider;
-  }
-
-  public SubstitutionMapProvider getCssSubstitutionMapProvider() {
-    return provider;
-  }
+  export const CLOSURE = NULL_RENAMING_TYPE;
+  Object.defineProperty(RenamingType, 'CLOSURE', {
+    enumerable: true,
+    get: () => new RenamingType(new class implements SubstitutionMapProvider {
+      public get(): SubstitutionMap {
+        return new SplittingSubstitutionMap(new MinimalSubstitutionMap());
+      }
+    })
+  });
 }
+
+export { RenamingType };

--- a/src/com/google/common/css/compiler/commandline/renaming-type.ts
+++ b/src/com/google/common/css/compiler/commandline/renaming-type.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.common.css.compiler.commandline;
+
+import com.google.common.css.IdentitySubstitutionMap;
+import com.google.common.css.MinimalSubstitutionMap;
+import com.google.common.css.SimpleSubstitutionMap;
+import com.google.common.css.SplittingSubstitutionMap;
+import com.google.common.css.SubstitutionMap;
+import com.google.common.css.SubstitutionMapProvider;
+
+/**
+ * {@link RenamingType} is an enumeration of the possible values for the
+ * {@code --rename} option in {@link ClosureCommandLineCompiler}. Each
+ * corresponds to an implementation of {@link SubstitutionMapProvider} that
+ * creates a {@link SubstitutionMap} to reflect the type of renaming.
+ *
+ * @author bolinfest@google.com (Michael Bolin)
+ */
+enum RenamingType {
+  /** No renaming is done. */
+  NONE(new SubstitutionMapProvider() {
+    @Override
+    public SubstitutionMap get() {
+      return new IdentitySubstitutionMap();
+    }
+  }),
+
+  /** A trailing underscore is added to each part of a CSS class. */
+  DEBUG(new SubstitutionMapProvider() {
+    @Override
+    public SubstitutionMap get() {
+      // This wraps the SimpleSubstitutionMap in a SplittingSubstitutionMap so
+      // that can be used with goog.getCssName().
+      return new SplittingSubstitutionMap(new SimpleSubstitutionMap());
+    }
+  }),
+
+
+  /**
+   * Each chunk of a CSS class as delimited by '-' is renamed using the
+   * shortest available name.
+   */
+  CLOSURE(new SubstitutionMapProvider() {
+    @Override
+    public SubstitutionMap get() {
+      return new SplittingSubstitutionMap(new MinimalSubstitutionMap());
+    }
+  }),
+  ;
+
+  private final SubstitutionMapProvider provider;
+
+  private RenamingType(SubstitutionMapProvider provider) {
+    this.provider = provider;
+  }
+
+  public SubstitutionMapProvider getCssSubstitutionMapProvider() {
+    return provider;
+  }
+}

--- a/src/com/google/common/css/output-renaming-map-format.ts
+++ b/src/com/google/common/css/output-renaming-map-format.ts
@@ -194,12 +194,18 @@ class OutputRenamingMapFormatImpl implements OutputRenamingMapFormat {
 
 /* tslint:disable:no-namespace */
 namespace OutputRenamingMapFormat {
+  const NULL_FORMAT = new OutputRenamingMapFormatImpl('');
+
   /**
    * Reads/Writes the mapping as JSON, passed as an argument to
    * {@code goog.setCssNameMapping()}. Designed for use with the Closure
    * Library in compiled mode.
    */
-  export const CLOSURE_COMPILED = () => new OutputRenamingMapFormatImpl("goog.setCssNameMapping(%s);\n");
+  export const CLOSURE_COMPILED = NULL_FORMAT;
+  Object.defineProperty(OutputRenamingMapFormat, 'CLOSURE_COMPILED', {
+    enumerable: true,
+    get: () => new OutputRenamingMapFormatImpl("goog.setCssNameMapping(%s);\n")
+  });
 
   /**
    * Reads/Writes the mapping as JSON, passed as an argument to
@@ -208,36 +214,53 @@ namespace OutputRenamingMapFormat {
    * name substitutions are taken as-is, which allows, e.g., using
    * {@code SimpleSubstitutionMap} with class names containing hyphens.
    */
-  export const CLOSURE_COMPILED_BY_WHOLE = () => new OutputRenamingMapFormatImpl("goog.setCssNameMapping(%s, 'BY_WHOLE');\n");
+  export const CLOSURE_COMPILED_BY_WHOLE = NULL_FORMAT;
+  Object.defineProperty(OutputRenamingMapFormat, 'CLOSURE_COMPILED_BY_WHOLE', {
+    enumerable: true,
+    get: () => new OutputRenamingMapFormatImpl("goog.setCssNameMapping(%s, 'BY_WHOLE');\n")
+  });
 
   /**
    * Before writing the mapping as CLOSURE_COMPILED, split the css name maps by hyphens and write
    * out each piece individually. see {@code CLOSURE_COMPILED}
    */
+  export const CLOSURE_COMPILED_SPLIT_HYPHENS = NULL_FORMAT;
   class ClosureCompiledSplitHyphensImpl extends OutputRenamingMapFormatImpl {
     constructor() { super("goog.setCssNameMapping(%s);\n"); }
     writeRenamingMap(renamingMap: Map<string, string>, renamingMapWriter: stream.Writable) {
       super.writeRenamingMap(OutputRenamingMapFormatImpl.splitEntriesOnHyphens(renamingMap), renamingMapWriter);
     }
   };
-  export const CLOSURE_COMPILED_SPLIT_HYPHENS = () => new ClosureCompiledSplitHyphensImpl();
+  Object.defineProperty(OutputRenamingMapFormat, 'CLOSURE_COMPILED_SPLIT_HYPHENS', {
+    enumerable: true,
+    get: () => new ClosureCompiledSplitHyphensImpl()
+  });
 
   /**
    * Reads/Writes the mapping as JSON, assigned to the global JavaScript variable
    * {@code CLOSURE_CSS_NAME_MAPPING}. Designed for use with the Closure
    * Library in uncompiled mode.
    */
-  export const CLOSURE_UNCOMPILED = () => new OutputRenamingMapFormatImpl("CLOSURE_CSS_NAME_MAPPING = %s;\n");
+  export const CLOSURE_UNCOMPILED = NULL_FORMAT;
+  Object.defineProperty(OutputRenamingMapFormat, 'CLOSURE_UNCOMPILED', {
+    enumerable: true,
+    get: () => new OutputRenamingMapFormatImpl("CLOSURE_CSS_NAME_MAPPING = %s;\n")
+  });
 
   /**
    * Reads/Writes the mapping as JSON.
    */
-  export const JSON = () => new OutputRenamingMapFormatImpl();
+  export const JSON = NULL_FORMAT;
+  Object.defineProperty(OutputRenamingMapFormat, 'JSON', {
+    enumerable: true,
+    get: () => new OutputRenamingMapFormatImpl()
+  });
 
   /**
    * Reads/Writes the mapping from/in a .properties file format, such that it can be read
    * by {@link Properties}.
    */
+  export const PROPERTIES = NULL_FORMAT;
   class PropertiesImpl extends OutputRenamingMapFormatImpl {
     writeRenamingMap(renamingMap: Map<string, string>, renamingMapWriter: stream.Writable) {
       OutputRenamingMapFormatImpl.writeOnePerLine('=', renamingMap, renamingMapWriter);
@@ -253,12 +276,16 @@ namespace OutputRenamingMapFormat {
       await OutputRenamingMapFormatImpl.readOnePerLine('=', inReadable, builder);
     }
   };
-  export const PROPERTIES = () => new PropertiesImpl();
+  Object.defineProperty(OutputRenamingMapFormat, 'PROPERTIES', {
+    enumerable: true,
+    get: () => new PropertiesImpl()
+  });
 
   /**
    * This is the current default behavior for output maps. Still used for
    * legacy reasons.
    */
+  export const JSCOMP_VARIABLE_MAP = NULL_FORMAT;
   class JscompVariableMapImpl extends OutputRenamingMapFormatImpl {
     writeRenamingMap(renamingMap: Map<string, string>, renamingMapWriter: stream.Writable) {
       OutputRenamingMapFormatImpl.writeOnePerLine(':', renamingMap, renamingMapWriter);
@@ -268,7 +295,10 @@ namespace OutputRenamingMapFormat {
       await OutputRenamingMapFormatImpl.readOnePerLine(':', inReadable, builder);
     }
   };
-  export const JSCOMP_VARIABLE_MAP = () => new JscompVariableMapImpl();
+  Object.defineProperty(OutputRenamingMapFormat, 'JSCOMP_VARIABLE_MAP', {
+    enumerable: true,
+    get: () => new JscompVariableMapImpl()
+  });
 }
 
 export { OutputRenamingMapFormat };

--- a/src/com/google/common/css/renaming-type.ts
+++ b/src/com/google/common/css/renaming-type.ts
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-import { IdentitySubstitutionMap } from '../../identity-substitution-map';
-import { MinimalSubstitutionMap } from '../../minimal-substitution-map';
-import { OutputRenamingMapFormat } from '../../output-renaming-map-format';
-import { PrefixingSubstitutionMap } from '../../prefixing-substitution-map';
-import { RecordingSubstitutionMap } from '../../recording-substitution-map';
-import { SimpleSubstitutionMap } from '../../simple-substitution-map';
-import { SplittingSubstitutionMap } from '../../splitting-substitution-map';
-import { SubstitutionMap } from '../../substitution-map';
-import { SubstitutionMapProvider } from '../../substitution-map-provider';
+import { IdentitySubstitutionMap } from './identity-substitution-map';
+import { MinimalSubstitutionMap } from './minimal-substitution-map';
+import { SimpleSubstitutionMap } from './simple-substitution-map';
+import { SplittingSubstitutionMap } from './splitting-substitution-map';
+import { SubstitutionMap } from './substitution-map';
+import { SubstitutionMapProvider } from './substitution-map-provider';
 
 /**
  * {@link RenamingType} is an enumeration of the possible values for the

--- a/src/com/google/common/css/substitution-map-provider.ts
+++ b/src/com/google/common/css/substitution-map-provider.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.google.common.css;
+import {SubstitutionMap} from './substitution-map';
 
 /**
  * Provides substitution maps for use with command-line compilers.
  *
  * Any implementation should provide a parameterless constructor, as the
- * provider is instantiated via {@link Class#newInstance()}.
+ * provider is instantiated via {@link Function.prototype.bind#call()}.
  *
  */
-public interface SubstitutionMapProvider {
+export interface SubstitutionMapProvider {
   /**
    * Gets the substitution map.
    *
    * @return The substitution map provided by this class.
    */
-  SubstitutionMap get();
+  get(): SubstitutionMap;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,13 @@
 import * as fs from 'fs';
 import * as postcss from 'postcss';
 import * as selectorParser from 'postcss-selector-parser';
-import { IdentitySubstitutionMap } from './src/com/google/common/css/identity-substitution-map';
-import { MinimalSubstitutionMap } from './src/com/google/common/css/minimal-substitution-map';
-import { OutputRenamingMapFormat } from './src/com/google/common/css/output-renaming-map-format';
-import { PrefixingSubstitutionMap } from './src/com/google/common/css/prefixing-substitution-map';
-import { RecordingSubstitutionMap } from './src/com/google/common/css/recording-substitution-map';
-import { SimpleSubstitutionMap } from './src/com/google/common/css/simple-substitution-map';
-import { SplittingSubstitutionMap } from './src/com/google/common/css/splitting-substitution-map';
+import { IdentitySubstitutionMap } from './com/google/common/css/identity-substitution-map';
+import { MinimalSubstitutionMap } from './com/google/common/css/minimal-substitution-map';
+import { OutputRenamingMapFormat } from './com/google/common/css/output-renaming-map-format';
+import { PrefixingSubstitutionMap } from './com/google/common/css/prefixing-substitution-map';
+import { RecordingSubstitutionMap } from './com/google/common/css/recording-substitution-map';
+import { SimpleSubstitutionMap } from './com/google/common/css/simple-substitution-map';
+import { SplittingSubstitutionMap } from './com/google/common/css/splitting-substitution-map';
 
 const RENAMING_TYPE = {
   none: () => new IdentitySubstitutionMap(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,27 +17,12 @@
 import * as fs from 'fs';
 import * as postcss from 'postcss';
 import * as selectorParser from 'postcss-selector-parser';
-import { IdentitySubstitutionMap } from './com/google/common/css/identity-substitution-map';
-import { MinimalSubstitutionMap } from './com/google/common/css/minimal-substitution-map';
 import { OutputRenamingMapFormat } from './com/google/common/css/output-renaming-map-format';
 import { PrefixingSubstitutionMap } from './com/google/common/css/prefixing-substitution-map';
 import { RecordingSubstitutionMap } from './com/google/common/css/recording-substitution-map';
-import { SimpleSubstitutionMap } from './com/google/common/css/simple-substitution-map';
-import { SplittingSubstitutionMap } from './com/google/common/css/splitting-substitution-map';
+import { RENAMING_TYPE, Options } from './options';
 
-const RENAMING_TYPE = {
-  none: () => new IdentitySubstitutionMap(),
-  debug: () => new SplittingSubstitutionMap(new SimpleSubstitutionMap()),
-  closure: () => new SplittingSubstitutionMap(new MinimalSubstitutionMap()),
-};
-
-interface Options {
-  renamingType?: keyof typeof RENAMING_TYPE;
-  outputRenamingMap?: string | null;
-  cssRenamingPrefix?: string | null;
-}
-
-module.exports = postcss.plugin(
+export = postcss.plugin(
   'postcss-rename',
   (options: Partial<Options> = {}) => {
     return (root: postcss.Root) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export = postcss.plugin(
       if (opts.outputRenamingMap) {
         const renamingMap = new Map([...substitutionMap.getMappings()]);
         const writer = fs.createWriteStream(opts.outputRenamingMap);
-        OutputRenamingMapFormat.CLOSURE_COMPILED_SPLIT_HYPHENS().writeRenamingMap(
+        OutputRenamingMapFormat.CLOSURE_COMPILED_SPLIT_HYPHENS.writeRenamingMap(
           renamingMap,
           writer
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ import * as selectorParser from 'postcss-selector-parser';
 import { OutputRenamingMapFormat } from './com/google/common/css/output-renaming-map-format';
 import { PrefixingSubstitutionMap } from './com/google/common/css/prefixing-substitution-map';
 import { RecordingSubstitutionMap } from './com/google/common/css/recording-substitution-map';
-import { RENAMING_TYPE, Options } from './options';
+import { Options } from './options';
+import { RenamingType } from './com/google/common/css/renaming-type';
 
 export = postcss.plugin(
   'postcss-rename',
@@ -28,14 +29,18 @@ export = postcss.plugin(
     return (root: postcss.Root) => {
       const opts = Object.assign(
         {
-          renamingType: 'none',
+          renamingType: 'NONE',
           outputRenamingMap: '',
           cssRenamingPrefix: '',
-        },
+        } as Options,
         options
       );
 
-      let map = RENAMING_TYPE[opts.renamingType]();
+      const renamingType = (RenamingType as {})[opts.renamingType];
+      let map = (renamingType as RenamingType)
+          .getCssSubstitutionMapProvider()
+          .get();
+
       if (opts.cssRenamingPrefix) {
         map = new PrefixingSubstitutionMap(map, opts.cssRenamingPrefix);
       }

--- a/src/options.ts
+++ b/src/options.ts
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-import { IdentitySubstitutionMap } from './com/google/common/css/identity-substitution-map';
-import { MinimalSubstitutionMap } from './com/google/common/css/minimal-substitution-map';
-import { SimpleSubstitutionMap } from './com/google/common/css/simple-substitution-map';
-import { SplittingSubstitutionMap } from './com/google/common/css/splitting-substitution-map';
-
-export const RENAMING_TYPE = {
-  none: () => new IdentitySubstitutionMap(),
-  debug: () => new SplittingSubstitutionMap(new SimpleSubstitutionMap()),
-  closure: () => new SplittingSubstitutionMap(new MinimalSubstitutionMap()),
-};
+import { RenamingType } from './com/google/common/css/renaming-type';
 
 export interface Options {
-  renamingType?: keyof typeof RENAMING_TYPE;
+  renamingType?: keyof typeof RenamingType;
   outputRenamingMap?: string | null;
   cssRenamingPrefix?: string | null;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IdentitySubstitutionMap } from './com/google/common/css/identity-substitution-map';
+import { MinimalSubstitutionMap } from './com/google/common/css/minimal-substitution-map';
+import { SimpleSubstitutionMap } from './com/google/common/css/simple-substitution-map';
+import { SplittingSubstitutionMap } from './com/google/common/css/splitting-substitution-map';
+
+export const RENAMING_TYPE = {
+  none: () => new IdentitySubstitutionMap(),
+  debug: () => new SplittingSubstitutionMap(new SimpleSubstitutionMap()),
+  closure: () => new SplittingSubstitutionMap(new MinimalSubstitutionMap()),
+};
+
+export interface Options {
+  renamingType?: keyof typeof RENAMING_TYPE;
+  outputRenamingMap?: string | null;
+  cssRenamingPrefix?: string | null;
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,21 +46,21 @@ it('does nothing with none renaming type', async () => {
   const input = await read('default.css');
   const expectedOutput = input;
 
-  assertPostcss(await run(input, { renamingType: 'none' }), expectedOutput);
+  assertPostcss(await run(input, { renamingType: 'NONE' }), expectedOutput);
 });
 
 it('renames with debug renaming type', async () => {
   const input = await read('default.css');
   const expectedOutput = await read('default.debug.css');
 
-  assertPostcss(await run(input, { renamingType: 'debug' }), expectedOutput);
+  assertPostcss(await run(input, { renamingType: 'DEBUG' }), expectedOutput);
 });
 
 it('renames with closure renaming type', async () => {
   const input = await read('default.css');
   const expectedOutput = await read('default.closure.css');
 
-  assertPostcss(await run(input, { renamingType: 'closure' }), expectedOutput);
+  assertPostcss(await run(input, { renamingType: 'CLOSURE' }), expectedOutput);
 });
 
 it('renames with prefix', async () => {
@@ -75,7 +75,7 @@ it('outputs renaming map as expected', async () => {
   const expectedOutput = await read('renaming_map.js');
 
   mockFs({ 'temp/': {} });
-  await run(input, { renamingType: 'closure', outputRenamingMap: 'temp/renaming_map.js' });
+  await run(input, { renamingType: 'CLOSURE', outputRenamingMap: 'temp/renaming_map.js' });
   const output = (await fs.readFile('temp/renaming_map.js')).toString();
   mockFs.restore();
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,7 +19,7 @@ import * as mockFs from 'mock-fs';
 import * as path from 'path';
 import * as postcss from 'postcss';
 
-const plugin = require('../');
+const plugin = require('../src');
 
 async function run(input: string, opts?: Object) {
   return await postcss([plugin(opts)]).process(input, { from: undefined });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,10 +18,10 @@ import {promises as fs} from 'fs';
 import * as mockFs from 'mock-fs';
 import * as path from 'path';
 import * as postcss from 'postcss';
+import { Options } from '../src/options';
+import plugin = require('../src');
 
-const plugin = require('../src');
-
-async function run(input: string, opts?: Object) {
+async function run(input: string, opts?: Options) {
   return await postcss([plugin(opts)]).process(input, { from: undefined });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "allowJs": true
   },
   "include": [
-    "*.ts", "src/com/google/common/css/*.js"
+    "src/com/google/common/css/*.js",
+    "src/index.ts"
   ],
 }


### PR DESCRIPTION
Porting SubstitutionMapProvider allows custom substitution maps to be provided, if the PostCSS plugin options are modified to accept them. For example, imagine a `substitutionMapProvider` plugin option that accepts a concrete implementation. Currently users must use one of the preset substitution maps, but they could supply one of their own so long as it implements the interface.

Porting RenamingType updates the `renamingType` PostCSS plugin option to match Closure Stylesheet's behavior.

OutputRenamingMapFormat was already ported, but following how RenamingType was ported, it's modified to behave more like its Java predecessor.