### PR TITLE
Add yarn test to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial  # Ubuntu 16.04
 language: node_js
 node_js:
-  - 13
+  - lts/*
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: xenial  # Ubuntu 16.04
+language: node_js
+node_js:
+  - 13
 
 addons:
   apt:
@@ -9,5 +12,6 @@ addons:
     - bazel
 
 script:
+  - yarn test
   - bazel build //...
   - bazel test //... --verbose_failures

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,5 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^com_google_closure_stylesheets/(.*)$': '<rootDir>/$1',
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build"
   ],
   "scripts": {
-    "test": "jest && eslint .",
-    "check": "gts check",
+    "test": "jest",
+    "check": "eslint .",
     "clean": "gts clean",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,4 +24,11 @@
     "strict": false,
     "allowJs": true
   },
+  "exclude": [
+    "bazel-*/",
+    "build/",
+    "test/",
+    "jest.config.js",
+    "prettier.config.js"
+  ]
 }


### PR DESCRIPTION
As set up in package.json currently, `yarn test` will run `jest` and `eslint .`.

Closes #9, Closes #11