### PR TITLE
Don't use import path aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,11 @@
 import fs from 'fs';
 import postcss from 'postcss';
 import selectorParser from 'postcss-selector-parser';
-import { OutputRenamingMapFormat } from 'com_google_closure_stylesheets/src/com/google/common/css/output-renaming-map-format';
-import { PrefixingSubstitutionMap } from 'com_google_closure_stylesheets/src/com/google/common/css/prefixing-substitution-map';
-import { RecordingSubstitutionMap } from 'com_google_closure_stylesheets/src/com/google/common/css/recording-substitution-map';
-import { Options } from 'com_google_closure_stylesheets/src/options';
-import { RenamingType } from 'com_google_closure_stylesheets/src/com/google/common/css/renaming-type';
+import { OutputRenamingMapFormat } from './com/google/common/css/output-renaming-map-format';
+import { PrefixingSubstitutionMap } from './com/google/common/css/prefixing-substitution-map';
+import { RecordingSubstitutionMap } from './com/google/common/css/recording-substitution-map';
+import { Options } from './options';
+import { RenamingType } from './com/google/common/css/renaming-type';
 
 export = postcss.plugin('postcss-rename', (options: Partial<Options> = {}) => {
   return (root: postcss.Root) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,9 +19,9 @@ import {promises as fs} from 'fs';
 import mockFs from 'mock-fs';
 import path from 'path';
 import postcss from 'postcss';
-import plugin from 'com_google_closure_stylesheets/src';
-import { Options } from 'com_google_closure_stylesheets/src/options';
-import { OutputRenamingMapFormat } from 'com_google_closure_stylesheets/src/com/google/common/css/output-renaming-map-format';
+import plugin from '../src';
+import { Options } from '../src/options';
+import { OutputRenamingMapFormat } from '../src/com/google/common/css/output-renaming-map-format';
 
 async function run(input: string, opts?: Options) {
   return await postcss([plugin(opts)]).process(input, { from: undefined });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,6 @@
     "outDir": "build",
     "module": "commonjs",
     "baseUrl": ".",
-    "paths": {
-      "com_google_closure_stylesheets/*": ["*"],
-    },
     "esModuleInterop": true,
     "lib": [
       "es5",


### PR DESCRIPTION
Instead use relative imports. This fixes built .d.ts files, which retain path aliases even though the alias isn't set up in the build output.

The path alias was previously set up in the process of prototyping this project because I ran into errors in Visual Studio Code with detecting relative imports. This seems to be resolved now.