### PR TITLE
Apply skiplist to cssname parts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const plugin = ({
             node.value
               .split('-')
               .map(part => {
-                const newPart = rename(part);
+                const newPart = exceptSet.has(part) ? part : rename(part);
                 if (outputMap) outputMap[part] = newPart;
                 return newPart;
               })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -229,6 +229,17 @@ describe('with strategy "debug"', () => {
         '.container_, .full-height .image_.full_-width_ {}'
       );
     });
+
+    it("doesn't map excluded parts", async () => {
+      assertPostcss(
+        await run(INPUT, {
+          strategy: 'debug',
+          except: ['full'],
+          by: 'part',
+        }),
+        '.container_, .full-height_ .image_.full-width_ {}'
+      );
+    });
   });
 });
 


### PR DESCRIPTION
When renaming by part, skip renaming parts that are in the except list of cssnames. This aligns renaming behavior with the  was Google's module set server does renaming.