### PR TITLE
Support for regexes in 'except'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ const plugin = ({
 
       function skip(nodeValue: string): boolean {
         if (exceptSet.has(nodeValue)) return true;
-        for (var val of exceptSet) 
+        for (const val of exceptSet)
           if (val instanceof RegExp && val.test(nodeValue)) return true;
         return false;
       }

--- a/src/minimal-renamer.ts
+++ b/src/minimal-renamer.ts
@@ -66,10 +66,10 @@ export class MinimalRenamer {
    * Creates a new MinimalSubstitutionMap that generates CSS names from the
    * specified set of characters.
    *
-   * @param except A set of CSS names that may not be returned as the output
-   *     from a substitution lookup.
+   * @param skip A function which decides if given CSS names may not be
+   *     returned as the output from a substitution lookup.
    */
-  constructor(private readonly except = new Set<string>()) {}
+  constructor(private readonly skip: (nodeValue: string) => boolean) {}
 
   rename(key: string): string {
     let value = this.renames.get(key);
@@ -77,7 +77,7 @@ export class MinimalRenamer {
 
     do {
       value = toShortName(this.nextIndex++);
-    } while (this.except.has(value));
+    } while (this.skip(value));
 
     this.renames.set(key, value);
     return value;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,7 +90,7 @@ describe('with strategy "none"', () => {
           container: 'container',
           image: 'image',
         },
-        {except: [/^full-.*$/]}
+        {except: [/full/]}
       );
     });
 
@@ -197,7 +197,7 @@ describe('with strategy "debug"', () => {
 
     it("doesn't map excluded regexes", async () => {
       assertPostcss(
-        await run(INPUT, {strategy: 'debug', except: [/^full-.*$/]}),
+        await run(INPUT, {strategy: 'debug', except: [/full/]}),
         '.container_, .full-height .image_.full-width {}'
       );
     });
@@ -266,7 +266,7 @@ describe('with strategy "debug"', () => {
       assertPostcss(
         await run(INPUT, {
           strategy: 'debug',
-          except: [/^full-.*$/],
+          except: [/full/],
           by: 'part',
         }),
         '.container_, .full-height .image_.full-width {}'
@@ -321,7 +321,7 @@ describe('with strategy "minimal"', () => {
 
     it("doesn't map excluded regexes", async () => {
       assertPostcss(
-        await run(INPUT, {strategy: 'minimal', except: [/^full-.*$/]}),
+        await run(INPUT, {strategy: 'minimal', except: [/full/]}),
         '.a, .full-height .b.full-width {}'
       );
     });
@@ -385,7 +385,7 @@ describe('with strategy "minimal"', () => {
       assertPostcss(
         await run(INPUT, {
           strategy: 'minimal',
-          except: [/^full-.*$/],
+          except: [/full/],
           by: 'part',
         }),
         '.a, .full-height .b.full-width {}'
@@ -462,7 +462,7 @@ describe('with a custom strategy', () => {
 
     it("doesn't map excluded regexes", async () => {
       assertPostcss(
-        await run(INPUT, {strategy, except: [/^full-.*$/]}),
+        await run(INPUT, {strategy, except: [/full/]}),
         '.er, .full-height .ge.full-width {}'
       );
     });
@@ -512,7 +512,7 @@ describe('with a custom strategy', () => {
       assertPostcss(
         await run(INPUT, {
           strategy,
-          except: [/^full-.*$/],
+          except: [/full/],
           by: 'part',
         }),
         '.er, .full-height .ge.full-width {}'

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -83,6 +83,17 @@ describe('with strategy "none"', () => {
       );
     });
 
+    it('omits excluded regexes from the output map', async () => {
+      await assertMapEquals(
+        INPUT,
+        {
+          container: 'container',
+          image: 'image',
+        },
+        {except: [/^full-.*$/]}
+      );
+    });
+
     it('includes the prefix in the output map', async () => {
       await assertMapEquals(
         INPUT,
@@ -122,6 +133,20 @@ describe('with strategy "none"', () => {
           width: 'width',
         },
         {except: ['full-height'], by: 'part'}
+      );
+    });
+
+    it('omits part that only appear in excluded regexes from the output map', async () => {
+      await assertMapEquals(
+        INPUT,
+        {
+          container: 'container',
+          full: 'full',
+          image: 'image',
+          width: 'width',
+          height: 'height',
+        },
+        {except: ['full-.*'], by: 'part'}
       );
     });
 
@@ -167,6 +192,13 @@ describe('with strategy "debug"', () => {
       assertPostcss(
         await run(INPUT, {strategy: 'debug', except: ['full-height']}),
         '.container_, .full-height .image_.full-width_ {}'
+      );
+    });
+
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {strategy: 'debug', except: [/^full-.*$/]}),
+        '.container_, .full-height .image_.full-width {}'
       );
     });
 
@@ -230,6 +262,17 @@ describe('with strategy "debug"', () => {
       );
     });
 
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {
+          strategy: 'debug',
+          except: [/^full-.*$/],
+          by: 'part',
+        }),
+        '.container_, .full-height .image_.full-width {}'
+      );
+    });
+
     it("doesn't map excluded parts", async () => {
       assertPostcss(
         await run(INPUT, {
@@ -276,10 +319,24 @@ describe('with strategy "minimal"', () => {
       );
     });
 
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {strategy: 'minimal', except: [/^full-.*$/]}),
+        '.a, .full-height .b.full-width {}'
+      );
+    });
+
     it("doesn't produce a name that would be excluded", async () => {
       assertPostcss(
         await run(INPUT, {strategy: 'minimal', except: ['b']}),
         '.a, .c .d.e {}'
+      );
+    });
+
+    it("doesn't produce a name that would be excluded with regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {strategy: 'minimal', except: [/^a|b$/]}),
+        '.c, .d .e.f {}'
       );
     });
   });
@@ -324,10 +381,28 @@ describe('with strategy "minimal"', () => {
       );
     });
 
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {
+          strategy: 'minimal',
+          except: [/^full-.*$/],
+          by: 'part',
+        }),
+        '.a, .full-height .b.full-width {}'
+      );
+    });
+
     it("doesn't produce a name that would be excluded", async () => {
       assertPostcss(
         await run(INPUT, {strategy: 'minimal', except: ['b'], by: 'part'}),
         '.a, .c-d .e.c-f {}'
+      );
+    });
+
+    it("doesn't produce a name that would be with regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {strategy: 'minimal', except: [/^a|b$/], by: 'part'}),
+        '.c, .d-e .f.d-g {}'
       );
     });
   });
@@ -384,6 +459,13 @@ describe('with a custom strategy', () => {
         '.er, .full-height .ge.th {}'
       );
     });
+
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {strategy, except: [/^full-.*$/]}),
+        '.er, .full-height .ge.full-width {}'
+      );
+    });
   });
 
   describe('in by-part mode', () => {
@@ -423,6 +505,17 @@ describe('with a custom strategy', () => {
           by: 'part',
         }),
         '.er, .full-height .ge.ll-th {}'
+      );
+    });
+
+    it("doesn't map excluded regexes", async () => {
+      assertPostcss(
+        await run(INPUT, {
+          strategy,
+          except: [/^full-.*$/],
+          by: 'part',
+        }),
+        '.er, .full-height .ge.full-width {}'
       );
     });
   });


### PR DESCRIPTION
Closes #38 

Regexes can now be present in `except` in addition to strings.

`except: [/full-.*/, ...]` would both skip `full-height` and `full-width`.

Instead of checking if a node value is present in the `exceptSet`, I moved the logic to a function named `skip`.

Allowing `except` to be a function would also be nice, what do you think?