### PR TITLE
Make renaming synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-dev
+## 0.7.0
 
 * Changed the plugin to run synchronously. This is a breaking change if you
 expect this plugin to run asynchronously.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0-dev
+
+* Changed the plugin to run synchronously. This is a breaking change if you
+expect this plugin to run asynchronously.
+
+
 ## 0.6.1
 
 * Don't mangle `@keyframes` breakpoints with decimal points.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-rename",
-  "version": "0.6.1",
+  "version": "0.7.0-dev",
   "description": "A PostCSS plugin to replace class names based on a customizable renaming scheme.",
   "keywords": [
     "postcss",

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ const plugin = ({
             ruleNode.parent.type !== 'atrule' ||
             !ruleNode.parent.name.endsWith('keyframes')
           ) {
-            selectorProcessor.process(ruleNode);
+            selectorProcessor.processSync(ruleNode, {updateSelector: true});
           }
         },
         OnceExit() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,9 +68,7 @@ const plugin = ({
         throw new Error(`Unknown mode "${by}".`);
       }
 
-      const alreadySeenNodes: Set<
-        selectorParser.ClassName | selectorParser.Identifier
-      > = new Set();
+      const alreadySeenNodes = new Set();
 
       function renameNode(
         node: selectorParser.ClassName | selectorParser.Identifier

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,10 @@ const plugin = ({
         throw new Error(`Unknown mode "${by}".`);
       }
 
+      const alreadySeenNodes: Set<
+        selectorParser.ClassName | selectorParser.Identifier
+      > = new Set();
+
       function renameNode(
         node: selectorParser.ClassName | selectorParser.Identifier
       ) {
@@ -109,6 +113,11 @@ const plugin = ({
             ruleNode.parent.type !== 'atrule' ||
             !ruleNode.parent.name.endsWith('keyframes')
           ) {
+            if (alreadySeenNodes.has(ruleNode)) {
+              return;
+            }
+
+            alreadySeenNodes.add(ruleNode);
             selectorProcessor.processSync(ruleNode, {updateSelector: true});
           }
         },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,11 +35,11 @@ function assertPostcss(result: LazyResult, output: string): void {
 function assertMapEquals(
   input: string,
   expected: {[key: string]: string},
-  options: plugin.Options = {},
+  options: plugin.Options = {}
 ): void {
   run(input, {
     ...options,
-    outputMapCallback: (map) => expect(map).toEqual(expected),
+    outputMapCallback: map => expect(map).toEqual(expected),
   });
 }
 
@@ -73,7 +73,7 @@ describe('with strategy "none"', () => {
     it('adds a prefix', () => {
       assertPostcss(
         run(INPUT, {prefix: 'pf-'}),
-        '.pf-container, .pf-full-height .pf-image.pf-full-width {}',
+        '.pf-container, .pf-full-height .pf-image.pf-full-width {}'
       );
     });
 
@@ -94,7 +94,7 @@ describe('with strategy "none"', () => {
           image: 'image',
           'full-width': 'full-width',
         },
-        {except: ['full-height']},
+        {except: ['full-height']}
       );
     });
 
@@ -105,7 +105,7 @@ describe('with strategy "none"', () => {
           container: 'container',
           image: 'image',
         },
-        {except: [/full/]},
+        {except: [/full/]}
       );
     });
 
@@ -118,7 +118,7 @@ describe('with strategy "none"', () => {
           image: 'pf-image',
           'full-width': 'pf-full-width',
         },
-        {prefix: 'pf-'},
+        {prefix: 'pf-'}
       );
     });
   });
@@ -134,7 +134,7 @@ describe('with strategy "none"', () => {
           image: 'image',
           width: 'width',
         },
-        {by: 'part'},
+        {by: 'part'}
       );
     });
 
@@ -147,7 +147,7 @@ describe('with strategy "none"', () => {
           image: 'image',
           width: 'width',
         },
-        {except: ['full-height'], by: 'part'},
+        {except: ['full-height'], by: 'part'}
       );
     });
 
@@ -161,7 +161,7 @@ describe('with strategy "none"', () => {
           width: 'width',
           height: 'height',
         },
-        {except: ['full-.*'], by: 'part'},
+        {except: ['full-.*'], by: 'part'}
       );
     });
 
@@ -175,7 +175,7 @@ describe('with strategy "none"', () => {
           image: 'image',
           width: 'width',
         },
-        {prefix: 'pf-', by: 'part'},
+        {prefix: 'pf-', by: 'part'}
       );
     });
   });
@@ -190,7 +190,7 @@ describe('with strategy "debug"', () => {
     it('adds underscores after every name', () => {
       assertPostcss(
         run(INPUT, {strategy: 'debug'}),
-        '.container_, .full-height_ .image_.full-width_ {}',
+        '.container_, .full-height_ .image_.full-width_ {}'
       );
     });
 
@@ -203,21 +203,21 @@ describe('with strategy "debug"', () => {
           image: 'image_',
           'full-width': 'full-width_',
         },
-        {strategy: 'debug'},
+        {strategy: 'debug'}
       );
     });
 
     it("doesn't map excluded names", () => {
       assertPostcss(
         run(INPUT, {strategy: 'debug', except: ['full-height']}),
-        '.container_, .full-height .image_.full-width_ {}',
+        '.container_, .full-height .image_.full-width_ {}'
       );
     });
 
     it("doesn't map excluded regexes", () => {
       assertPostcss(
         run(INPUT, {strategy: 'debug', except: [/full/]}),
-        '.container_, .full-height .image_.full-width {}',
+        '.container_, .full-height .image_.full-width {}'
       );
     });
 
@@ -226,7 +226,7 @@ describe('with strategy "debug"', () => {
         run('#container, #full-height, #image.full-width {}', {
           strategy: 'debug',
         }),
-        '#container, #full-height, #image.full-width_ {}',
+        '#container, #full-height, #image.full-width_ {}'
       );
     });
 
@@ -236,7 +236,7 @@ describe('with strategy "debug"', () => {
           strategy: 'debug',
           ids: true,
         }),
-        '#container_, #full-height_, #image_.full-width_ {}',
+        '#container_, #full-height_, #image_.full-width_ {}'
       );
     });
   });
@@ -245,14 +245,14 @@ describe('with strategy "debug"', () => {
     it('adds underscores after every part', () => {
       assertPostcss(
         run(INPUT, {strategy: 'debug', by: 'part'}),
-        '.container_, .full_-height_ .image_.full_-width_ {}',
+        '.container_, .full_-height_ .image_.full_-width_ {}'
       );
     });
 
     it('adds a prefix after underscoring', () => {
       assertPostcss(
         run(INPUT, {strategy: 'debug', prefix: 'pf-', by: 'part'}),
-        '.pf-container_, .pf-full_-height_ .pf-image_.pf-full_-width_ {}',
+        '.pf-container_, .pf-full_-height_ .pf-image_.pf-full_-width_ {}'
       );
     });
 
@@ -266,7 +266,7 @@ describe('with strategy "debug"', () => {
           image: 'image_',
           width: 'width_',
         },
-        {strategy: 'debug', by: 'part'},
+        {strategy: 'debug', by: 'part'}
       );
     });
 
@@ -277,7 +277,7 @@ describe('with strategy "debug"', () => {
           except: ['full-height'],
           by: 'part',
         }),
-        '.container_, .full-height .image_.full_-width_ {}',
+        '.container_, .full-height .image_.full_-width_ {}'
       );
     });
 
@@ -288,7 +288,7 @@ describe('with strategy "debug"', () => {
           except: [/full/],
           by: 'part',
         }),
-        '.container_, .full-height .image_.full-width {}',
+        '.container_, .full-height .image_.full-width {}'
       );
     });
 
@@ -299,7 +299,7 @@ describe('with strategy "debug"', () => {
           except: ['full'],
           by: 'part',
         }),
-        '.container_, .full-height_ .image_.full-width_ {}',
+        '.container_, .full-height_ .image_.full-width_ {}'
       );
     });
   });
@@ -318,7 +318,7 @@ describe('with strategy "minimal"', () => {
     it('adds a prefix after minimizing', () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', prefix: 'pf-'}),
-        '.pf-a, .pf-b .pf-c.pf-d {}',
+        '.pf-a, .pf-b .pf-c.pf-d {}'
       );
     });
 
@@ -331,35 +331,35 @@ describe('with strategy "minimal"', () => {
           image: 'c',
           'full-width': 'd',
         },
-        {strategy: 'minimal'},
+        {strategy: 'minimal'}
       );
     });
 
     it("doesn't map excluded names", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: ['full-height']}),
-        '.a, .full-height .b.c {}',
+        '.a, .full-height .b.c {}'
       );
     });
 
     it("doesn't map excluded regexes", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: [/full/]}),
-        '.a, .full-height .b.full-width {}',
+        '.a, .full-height .b.full-width {}'
       );
     });
 
     it("doesn't produce a name that would be excluded", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: ['b']}),
-        '.a, .c .d.e {}',
+        '.a, .c .d.e {}'
       );
     });
 
     it("doesn't produce a name that would be excluded with regexes", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: [/^a|b$/]}),
-        '.c, .d .e.f {}',
+        '.c, .d .e.f {}'
       );
     });
   });
@@ -368,14 +368,14 @@ describe('with strategy "minimal"', () => {
     it('maps parts to the shortest possible strings', () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', by: 'part'}),
-        '.a, .b-c .d.b-e {}',
+        '.a, .b-c .d.b-e {}'
       );
     });
 
     it('adds a prefix after minimizing', () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', prefix: 'pf-', by: 'part'}),
-        '.pf-a, .pf-b-c .pf-d.pf-b-e {}',
+        '.pf-a, .pf-b-c .pf-d.pf-b-e {}'
       );
     });
 
@@ -389,7 +389,7 @@ describe('with strategy "minimal"', () => {
           image: 'd',
           width: 'e',
         },
-        {strategy: 'minimal', by: 'part'},
+        {strategy: 'minimal', by: 'part'}
       );
     });
 
@@ -400,7 +400,7 @@ describe('with strategy "minimal"', () => {
           except: ['full-height'],
           by: 'part',
         }),
-        '.a, .full-height .b.c-d {}',
+        '.a, .full-height .b.c-d {}'
       );
     });
 
@@ -411,21 +411,21 @@ describe('with strategy "minimal"', () => {
           except: [/full/],
           by: 'part',
         }),
-        '.a, .full-height .b.full-width {}',
+        '.a, .full-height .b.full-width {}'
       );
     });
 
     it("doesn't produce a name that would be excluded", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: ['b'], by: 'part'}),
-        '.a, .c-d .e.c-f {}',
+        '.a, .c-d .e.c-f {}'
       );
     });
 
     it("doesn't produce a name that would be with regexes", () => {
       assertPostcss(
         run(INPUT, {strategy: 'minimal', except: [/^a|b$/], by: 'part'}),
-        '.c, .d-e .f.d-g {}',
+        '.c, .d-e .f.d-g {}'
       );
     });
   });
@@ -453,7 +453,7 @@ describe('with strategy "minimal"', () => {
 });
 
 describe('with a custom strategy', () => {
-  const strategy = (name) => name.substring(name.length - 2, name.length);
+  const strategy = name => name.substring(name.length - 2, name.length);
 
   describe('in by-whole mode', () => {
     it('maps names to the shortest possible strings', () => {
@@ -463,7 +463,7 @@ describe('with a custom strategy', () => {
     it('adds a prefix after renaming', () => {
       assertPostcss(
         run(INPUT, {strategy, prefix: 'pf-'}),
-        '.pf-er, .pf-ht .pf-ge.pf-th {}',
+        '.pf-er, .pf-ht .pf-ge.pf-th {}'
       );
     });
 
@@ -476,21 +476,21 @@ describe('with a custom strategy', () => {
           image: 'ge',
           'full-width': 'th',
         },
-        {strategy},
+        {strategy}
       );
     });
 
     it("doesn't map excluded names", () => {
       assertPostcss(
         run(INPUT, {strategy, except: ['full-height']}),
-        '.er, .full-height .ge.th {}',
+        '.er, .full-height .ge.th {}'
       );
     });
 
     it("doesn't map excluded regexes", () => {
       assertPostcss(
         run(INPUT, {strategy, except: [/full/]}),
-        '.er, .full-height .ge.full-width {}',
+        '.er, .full-height .ge.full-width {}'
       );
     });
   });
@@ -499,14 +499,14 @@ describe('with a custom strategy', () => {
     it('maps parts to the shortest possible strings', () => {
       assertPostcss(
         run(INPUT, {strategy, by: 'part'}),
-        '.er, .ll-ht .ge.ll-th {}',
+        '.er, .ll-ht .ge.ll-th {}'
       );
     });
 
     it('adds a prefix after renaming', () => {
       assertPostcss(
         run(INPUT, {strategy, prefix: 'pf-', by: 'part'}),
-        '.pf-er, .pf-ll-ht .pf-ge.pf-ll-th {}',
+        '.pf-er, .pf-ll-ht .pf-ge.pf-ll-th {}'
       );
     });
 
@@ -520,7 +520,7 @@ describe('with a custom strategy', () => {
           image: 'ge',
           width: 'th',
         },
-        {strategy, by: 'part'},
+        {strategy, by: 'part'}
       );
     });
 
@@ -531,7 +531,7 @@ describe('with a custom strategy', () => {
           except: ['full-height'],
           by: 'part',
         }),
-        '.er, .full-height .ge.ll-th {}',
+        '.er, .full-height .ge.ll-th {}'
       );
     });
 
@@ -542,7 +542,7 @@ describe('with a custom strategy', () => {
           except: [/full/],
           by: 'part',
         }),
-        '.er, .full-height .ge.full-width {}',
+        '.er, .full-height .ge.full-width {}'
       );
     });
   });


### PR DESCRIPTION
Since PostCSS has [issues with ordering when some plugins are asynchronous](https://github.com/postcss/postcss/issues/2047), this PR changes this plugin to run synchronously by using `processSync` over `process`.