### PR TITLE
Support at-rule property definitions in variable renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* Variable renaming now also renames variables defined by the `@property` rule.
+
 ## 0.8.0
 
 * Added variable renaming capabilities. Users who are interested in using the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-rename",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A PostCSS plugin to replace CSS names based on a customizable renaming scheme.",
   "keywords": [
     "postcss",

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -132,10 +132,6 @@ function plugin({
         alreadyProcessedAtRulePropertyNodes.add(atRuleNode);
 
         atRuleNode.params = renameVariable(atRuleNode.params);
-
-        atRuleNode.walkDecls(declarationNode => {
-          renameDeclaration(declarationNode);
-        });
       }
 
       return {

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -109,35 +109,31 @@ function plugin({
         return parsed.toString();
       }
 
-      const alreadyProcessedDeclarationNodes = new Set<Declaration>();
-
+      const alreadyProcessedDeclarations = new Set<Declaration>();
       function renameDeclaration(declarationNode: Declaration): void {
-        if (alreadyProcessedDeclarationNodes.has(declarationNode)) {
+        if (alreadyProcessedDeclarations.has(declarationNode)) {
           return;
         }
 
-        alreadyProcessedDeclarationNodes.add(declarationNode);
+        alreadyProcessedDeclarations.add(declarationNode);
 
         declarationNode.prop = renameVariable(declarationNode.prop);
         declarationNode.value = renameValue(declarationNode.value);
       }
 
-      const alreadyProcessedAtRulePropertyNodes = new Set<AtRule>();
-
+      const alreadyProcessedAtRules = new Set<AtRule>();
       function renameAtRuleProperty(atRuleNode: AtRule): void {
-        if (alreadyProcessedAtRulePropertyNodes.has(atRuleNode)) {
+        if (alreadyProcessedAtRules.has(atRuleNode)) {
           return;
         }
 
-        alreadyProcessedAtRulePropertyNodes.add(atRuleNode);
+        alreadyProcessedAtRules.add(atRuleNode);
 
         atRuleNode.params = renameVariable(atRuleNode.params);
       }
 
       return {
-        AtRule: {
-          property: renameAtRuleProperty,
-        },
+        AtRule: {property: renameAtRuleProperty},
         Declaration: renameDeclaration,
         OnceExit() {
           if (outputMapCallback) {

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import postcss, {Declaration} from 'postcss';
+import postcss, {AtRule, Declaration} from 'postcss';
 import valueParser from 'postcss-value-parser';
 import {type RenamingMap, type VariableRenamingOptions} from './options';
 import {type SkipPredicate, createSkipPredicate} from './skip';
@@ -109,19 +109,39 @@ function plugin({
         return parsed.toString();
       }
 
-      const alreadyProcessedNodes = new Set<Declaration>();
+      const alreadyProcessedDeclarationNodes = new Set<Declaration>();
+
       function renameDeclaration(declarationNode: Declaration): void {
-        if (alreadyProcessedNodes.has(declarationNode)) {
+        if (alreadyProcessedDeclarationNodes.has(declarationNode)) {
           return;
         }
 
-        alreadyProcessedNodes.add(declarationNode);
+        alreadyProcessedDeclarationNodes.add(declarationNode);
 
         declarationNode.prop = renameVariable(declarationNode.prop);
         declarationNode.value = renameValue(declarationNode.value);
       }
 
+      const alreadyProcessedAtRulePropertyNodes = new Set<AtRule>();
+
+      function renameAtRuleProperty(atRuleNode: AtRule): void {
+        if (alreadyProcessedAtRulePropertyNodes.has(atRuleNode)) {
+          return;
+        }
+
+        alreadyProcessedAtRulePropertyNodes.add(atRuleNode);
+
+        atRuleNode.params = renameVariable(atRuleNode.params);
+
+        atRuleNode.walkDecls(declarationNode => {
+          renameDeclaration(declarationNode);
+        });
+      }
+
       return {
+        AtRule: {
+          property: renameAtRuleProperty,
+        },
         Declaration: renameDeclaration,
         OnceExit() {
           if (outputMapCallback) {

--- a/test/variable.test.ts
+++ b/test/variable.test.ts
@@ -470,9 +470,13 @@ describe('with strategy "none"', () => {
     });
   });
 
-  describe('with @property (contains initial-value)', () => {
-    const input =
-      '@property --test-property { syntax: "<angle>"; initial-value: var(--initial); }';
+  describe('with @property', () => {
+    const input = `
+      @property --test-property {
+        syntax: "<angle>";
+        inherits: false;
+        initial-value: 45deg;
+      }`;
 
     it('does nothing with no options', () => {
       assertPostcss(run(input), input);
@@ -960,22 +964,29 @@ describe('with strategy "debug"', () => {
     });
   });
 
-  describe('with @property (contains initial-value)', () => {
-    const input =
-      '@property --test-property { syntax: "<angle>"; initial-value: var(--initial); }';
+  describe('with @property', () => {
+    const input = `
+      @property --test-property {
+        syntax: "<angle>";
+        inherits: false;
+        initial-value: 45deg;
+      }`;
+
+    const expected = `
+      @property --test-property_ {
+        syntax: "<angle>";
+        inherits: false;
+        initial-value: 45deg;
+      }`;
 
     it('adds an underscore after every name', () => {
-      assertPostcss(
-        run(input, {strategy: 'debug'}),
-        '@property --test-property_ { syntax: "<angle>"; initial-value: var(--initial_); }',
-      );
+      assertPostcss(run(input, {strategy: 'debug'}), expected);
     });
 
     it('emits an output map', () => {
       assertMapEquals(
         input,
         {
-          initial: 'initial_',
           'test-property': 'test-property_',
         },
         {
@@ -988,7 +999,6 @@ describe('with strategy "debug"', () => {
       assertMapEquals(
         input,
         {
-          initial: 'pf-initial_',
           'test-property': 'pf-test-property_',
         },
         {
@@ -1001,102 +1011,42 @@ describe('with strategy "debug"', () => {
     it('omits excluded names from the output map', () => {
       assertMapEquals(
         input,
-        {
-          'test-property': 'test-property_',
-        },
+        {},
         {
           strategy: 'debug',
-          except: ['initial'],
+          except: ['test-property'],
         },
       );
-    });
-  });
-
-  describe('with declaration + @property (contains initial-value) + declaration', () => {
-    it('adds an underscore after every name', () => {
-      const input = `
-        --initial: 45;
-        
-        @property --test-property {
-          syntax: "<angle>";
-          initial-value: var(--initial);
-        }
-
-        --test-property: 45;
-      `;
-
-      const expected = `
-        --initial_: 45;
-        
-        @property --test-property_ {
-          syntax: "<angle>";
-          initial-value: var(--initial_);
-        }
-
-        --test-property_: 45;
-      `;
-
-      assertPostcss(run(input, {strategy: 'debug'}), expected);
     });
   });
 });
 
 describe('with strategy "minimal"', () => {
-  describe('with declaration + @property (contains initial-value) + declaration', () => {
-    const input1 = `
-      --test-property: 45;
+  describe('with declaration + @property', () => {
+    const input = `
+      --test-property: 45deg;
         
       @property --test-property {
         syntax: "<angle>";
-        initial-value: var(--initial);
-      }
+        inherits: false;
+      }`;
 
-      --initial: 45;
-    `;
-
-    const expected1 = `
-      --a: 45;
+    const expected = `
+      --a: 45deg;
         
       @property --a {
         syntax: "<angle>";
-        initial-value: var(--b);
-      }
+        inherits: false;
+      }`;
 
-      --b: 45;
-    `;
-
-    const input2 = `
-      --initial: 45;
-        
-      @property --test-property {
-        syntax: "<angle>";
-        initial-value: var(--initial);
-      }
-
-      --test-property: 45;
-    `;
-
-    const expected2 = `
-      --a: 45;
-        
-      @property --b {
-        syntax: "<angle>";
-        initial-value: var(--a);
-      }
-
-      --b: 45;
-    `;
-
-    it('respects declaration order', () => {
-      assertPostcss(run(input1, {strategy: 'minimal'}), expected1);
-      assertPostcss(run(input2, {strategy: 'minimal'}), expected2);
+    it('maps names to the shortest possible strings', () => {
+      assertPostcss(run(input, {strategy: 'minimal'}), expected);
     });
 
     it('includes the prefix in the output map', () => {
       assertMapEquals(
-        input1,
+        input,
         {
-          initial: 'pf-b',
           'test-property': 'pf-a',
         },
         {
@@ -1104,12 +1054,35 @@ describe('with strategy "minimal"', () => {
           prefix: 'pf',
         },
       );
+    });
+  });
 
+  describe('with @property + declaration', () => {
+    const input = `  
+      @property --test-property {
+        syntax: "<angle>";
+        inherits: false;
+      }
+
+      --test-property: 45deg;`;
+
+    const expected = `  
+      @property --a {
+        syntax: "<angle>";
+        inherits: false;
+      }
+
+      --a: 45deg;`;
+
+    it('maps names to the shortest possible strings', () => {
+      assertPostcss(run(input, {strategy: 'minimal'}), expected);
+    });
+
+    it('includes the prefix in the output map', () => {
       assertMapEquals(
-        input2,
+        input,
         {
-          initial: 'pf-a',
-          'test-property': 'pf-b',
+          'test-property': 'pf-a',
         },
         {
           strategy: 'minimal',

--- a/test/variable.test.ts
+++ b/test/variable.test.ts
@@ -469,6 +469,19 @@ describe('with strategy "none"', () => {
       );
     });
   });
+
+  describe('with @property (contains initial-value)', () => {
+    const input =
+      '@property --test-property { syntax: "<angle>"; initial-value: var(--initial); }';
+
+    it('does nothing with no options', () => {
+      assertPostcss(run(input), input);
+    });
+
+    it('does nothing with an explicit strategy', () => {
+      assertPostcss(run(input, {strategy: 'none'}), input);
+    });
+  });
 });
 
 describe('with strategy "debug"', () => {
@@ -941,6 +954,165 @@ describe('with strategy "debug"', () => {
         },
         {
           strategy: 'debug',
+          prefix: 'pf',
+        },
+      );
+    });
+  });
+
+  describe('with @property (contains initial-value)', () => {
+    const input =
+      '@property --test-property { syntax: "<angle>"; initial-value: var(--initial); }';
+
+    it('adds an underscore after every name', () => {
+      assertPostcss(
+        run(input, {strategy: 'debug'}),
+        '@property --test-property_ { syntax: "<angle>"; initial-value: var(--initial_); }',
+      );
+    });
+
+    it('emits an output map', () => {
+      assertMapEquals(
+        input,
+        {
+          initial: 'initial_',
+          'test-property': 'test-property_',
+        },
+        {
+          strategy: 'debug',
+        },
+      );
+    });
+
+    it('includes the prefix in the output map', () => {
+      assertMapEquals(
+        input,
+        {
+          initial: 'pf-initial_',
+          'test-property': 'pf-test-property_',
+        },
+        {
+          strategy: 'debug',
+          prefix: 'pf',
+        },
+      );
+    });
+
+    it('omits excluded names from the output map', () => {
+      assertMapEquals(
+        input,
+        {
+          'test-property': 'test-property_',
+        },
+        {
+          strategy: 'debug',
+          except: ['initial'],
+        },
+      );
+    });
+  });
+
+  describe('with declaration + @property (contains initial-value) + declaration', () => {
+    it('adds an underscore after every name', () => {
+      const input = `
+        --initial: 45;
+        
+        @property --test-property {
+          syntax: "<angle>";
+          initial-value: var(--initial);
+        }
+
+        --test-property: 45;
+      `;
+
+      const expected = `
+        --initial_: 45;
+        
+        @property --test-property_ {
+          syntax: "<angle>";
+          initial-value: var(--initial_);
+        }
+
+        --test-property_: 45;
+      `;
+
+      assertPostcss(run(input, {strategy: 'debug'}), expected);
+    });
+  });
+});
+
+describe('with strategy "minimal"', () => {
+  describe('with declaration + @property (contains initial-value) + declaration', () => {
+    const input1 = `
+      --test-property: 45;
+        
+      @property --test-property {
+        syntax: "<angle>";
+        initial-value: var(--initial);
+      }
+
+      --initial: 45;
+    `;
+
+    const expected1 = `
+      --a: 45;
+        
+      @property --a {
+        syntax: "<angle>";
+        initial-value: var(--b);
+      }
+
+      --b: 45;
+    `;
+
+    const input2 = `
+      --initial: 45;
+        
+      @property --test-property {
+        syntax: "<angle>";
+        initial-value: var(--initial);
+      }
+
+      --test-property: 45;
+    `;
+
+    const expected2 = `
+      --a: 45;
+        
+      @property --b {
+        syntax: "<angle>";
+        initial-value: var(--a);
+      }
+
+      --b: 45;
+    `;
+
+    it('respects declaration order', () => {
+      assertPostcss(run(input1, {strategy: 'minimal'}), expected1);
+      assertPostcss(run(input2, {strategy: 'minimal'}), expected2);
+    });
+
+    it('includes the prefix in the output map', () => {
+      assertMapEquals(
+        input1,
+        {
+          initial: 'pf-b',
+          'test-property': 'pf-a',
+        },
+        {
+          strategy: 'minimal',
+          prefix: 'pf',
+        },
+      );
+
+      assertMapEquals(
+        input2,
+        {
+          initial: 'pf-a',
+          'test-property': 'pf-b',
+        },
+        {
+          strategy: 'minimal',
           prefix: 'pf',
         },
       );

--- a/test/variable.test.ts
+++ b/test/variable.test.ts
@@ -476,7 +476,8 @@ describe('with strategy "none"', () => {
         syntax: "<angle>";
         inherits: false;
         initial-value: 45deg;
-      }`;
+      }
+    `;
 
     it('does nothing with no options', () => {
       assertPostcss(run(input), input);
@@ -493,7 +494,8 @@ describe('with strategy "debug"', () => {
     const input = `
       .no-variables-here {
         absolutely: "nothing";
-      }`;
+      }
+    `;
 
     const options: plugin.Options = {
       strategy: 'debug',
@@ -970,14 +972,16 @@ describe('with strategy "debug"', () => {
         syntax: "<angle>";
         inherits: false;
         initial-value: 45deg;
-      }`;
+      }
+    `;
 
     const expected = `
       @property --test-property_ {
         syntax: "<angle>";
         inherits: false;
         initial-value: 45deg;
-      }`;
+      }
+    `;
 
     it('adds an underscore after every name', () => {
       assertPostcss(run(input, {strategy: 'debug'}), expected);

--- a/test/variable.test.ts
+++ b/test/variable.test.ts
@@ -1027,7 +1027,7 @@ describe('with strategy "minimal"', () => {
       --test-property: 45deg;
         
       @property --test-property {
-        syntax: "<angle>";
+        syntax: "*";
         inherits: false;
       }`;
 
@@ -1035,7 +1035,7 @@ describe('with strategy "minimal"', () => {
       --a: 45deg;
         
       @property --a {
-        syntax: "<angle>";
+        syntax: "*";
         inherits: false;
       }`;
 
@@ -1060,7 +1060,7 @@ describe('with strategy "minimal"', () => {
   describe('with @property + declaration', () => {
     const input = `  
       @property --test-property {
-        syntax: "<angle>";
+        syntax: "*";
         inherits: false;
       }
 
@@ -1068,7 +1068,7 @@ describe('with strategy "minimal"', () => {
 
     const expected = `  
       @property --a {
-        syntax: "<angle>";
+        syntax: "*";
         inherits: false;
       }
 


### PR DESCRIPTION
This PR adds support for renaming variables in CSS `@property` definitions. Resolves #82.

To maintain consistency with the existing codebase, I've implemented an `AtRule.property` processor using:

- `renameVariable` for property names
- `renameDeclaration` for internal declarations

I have added test cases to verify the implementation across all core strategies:

- [x] `none`
- [x] `debug`
- [x] `minimal` (including both declaration-first and property-first orderings)

If any further adjustments are needed, please let me know.